### PR TITLE
Fixed bug with odd langcodes

### DIFF
--- a/adiIRC/remote.ini
+++ b/adiIRC/remote.ini
@@ -1,6 +1,6 @@
 on 1:TEXT:*:#fuelrats,#ratchat: {
   if ($nick isin "MechaSqueak[BOT]") {
-    if ($regex(signal, $1-, /RATSIGNAL Case #(\d+) (PC|Xbox|Playstation|unknown platform)(?: )?(LEG|HOR|ODY)?(?: \(Code Red\))? – CMDR (.+?)(?: \(.*\))? – System: ".*"(?: ⚠️)? \(.+\) – Language: .+ \(([a-z]{2})(?:-\w{2,3}(?:-(?:[a-z]|[A-Z])*)?)?\)(?: – Nick: ([\w\[\]\^-{|}]+))?.?(?:\((?:ODY|HOR|LEG|XB|PS)_SIGNAL\))?.?/SF)) {
+    if ($regex(signal, $1-, /RATSIGNAL Case #(\d+) (PC|Xbox|Playstation|unknown platform)(?: )?(LEG|HOR|ODY)?(?: \(Code Red\))? – CMDR (.+?)(?: \(.*\))? – System: ".*"(?: ⚠️)? \(.+\) – Language: .+ \(([a-z]{2})(?:-\w{2,3}-?(?:[a-z]|[A-Z])*)?\)(?: – Nick: ([\w\[\]\^-{|}]+))?.?(?:\((?:ODY|HOR|LEG|XB|PS)_SIGNAL\))?.?/SF)) {
       if ($regml(signal, 6) == $null) {
         /set %nickname $regml(signal, 4)
       }

--- a/adiIRC/remote.ini
+++ b/adiIRC/remote.ini
@@ -1,6 +1,6 @@
 on 1:TEXT:*:#fuelrats,#ratchat: {
   if ($nick isin "MechaSqueak[BOT]") {
-    if ($regex(signal, $1-, /RATSIGNAL Case #(\d+) (PC|Xbox|Playstation|unknown platform)(?: )?(LEG|HOR|ODY)?(?: \(Code Red\))? – CMDR (.+?)(?: \(.*\))? – System: ".*"(?: ⚠️)? \(.+\) – Language: .+ \(([a-z]{2})(?:-\w{2,3}(?:-[a-z])?)?\)(?: – Nick: ([\w\[\]\^-{|}]+))?.?(?:\((?:ODY|HOR|LEG|XB|PS)_SIGNAL\))?.?/SF)) {
+    if ($regex(signal, $1-, /RATSIGNAL Case #(\d+) (PC|Xbox|Playstation|unknown platform)(?: )?(LEG|HOR|ODY)?(?: \(Code Red\))? – CMDR (.+?)(?: \(.*\))? – System: ".*"(?: ⚠️)? \(.+\) – Language: .+ \(([a-z]{2})(?:-\w{2,3}(?:-(?:[a-z]|[A-Z])*)?)?\)(?: – Nick: ([\w\[\]\^-{|}]+))?.?(?:\((?:ODY|HOR|LEG|XB|PS)_SIGNAL\))?.?/SF)) {
       if ($regml(signal, 6) == $null) {
         /set %nickname $regml(signal, 4)
       }

--- a/adiIRC/remote.ini
+++ b/adiIRC/remote.ini
@@ -1,6 +1,6 @@
 on 1:TEXT:*:#fuelrats,#ratchat: {
   if ($nick isin "MechaSqueak[BOT]") {
-    if ($regex(signal, $1-, /RATSIGNAL Case #(\d+) (PC|Xbox|Playstation|unknown platform)(?: )?(LEG|HOR|ODY)?(?: \(Code Red\))? – CMDR (.+?)(?: \(.*\))? – System: ".*"(?: ⚠️)? \(.+\) – Language: .+ \(([a-z]{2})(?:-\w{2,3})?\)(?: – Nick: ([\w\[\]\^-{|}]+))?.?(?:\((?:ODY|HOR|LEG|XB|PS)_SIGNAL\))?.?/SF)) {
+    if ($regex(signal, $1-, /RATSIGNAL Case #(\d+) (PC|Xbox|Playstation|unknown platform)(?: )?(LEG|HOR|ODY)?(?: \(Code Red\))? – CMDR (.+?)(?: \(.*\))? – System: ".*"(?: ⚠️)? \(.+\) – Language: .+ \(([a-z]{2})(?:-\w{2,3}(?:-[a-z])?)?\)(?: – Nick: ([\w\[\]\^-{|}]+))?.?(?:\((?:ODY|HOR|LEG|XB|PS)_SIGNAL\))?.?/SF)) {
       if ($regml(signal, 6) == $null) {
         /set %nickname $regml(signal, 4)
       }


### PR DESCRIPTION
For situations like:

 RATSIGNAL Case #3 PC ODY – CMDR Sir_Delryn – System: "FUELUM" (K Orange dwarf 89.2 LY from Sol) – Language: English (United Kingdom, Oxford English Dictionary spelling) (en-GB-oxendict) – Nick: Sir_Delryn (ODY_SIGNAL)